### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Take a look at code, it is not that sophisticated..
 
 ## Building and running
 
-###SBT
+### SBT
 
 Make sure you hava protoc installed (version 2.5!).
 On OSX:
@@ -45,7 +45,7 @@ sbt assembly
 ```
 Note: This will generate the protobuf java files and compile them as part of the project.
 
-###Maven
+### Maven
 
 Install Maven 3 & protobuf compiler (version 2.5!)
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
